### PR TITLE
Make TimePickerView respect startDate values for year, month, and day

### DIFF
--- a/frameworks/calendar/views/calendar.js
+++ b/frameworks/calendar/views/calendar.js
@@ -16,6 +16,10 @@ SCUI.CalendarView = SC.View.extend({
     if (selectedDate) this.set('monthStartOn', selectedDate.adjust({ day: 1 }));
   },
   
+  touchStart: function(evt) {
+    this.mouseDown(evt);
+  },
+
   mouseDown: function(evt) {
     var date = this._parseSelectedDate(evt.target.id);
     if (date) this.set('selectedDate', date);
@@ -27,6 +31,10 @@ SCUI.CalendarView = SC.View.extend({
     return YES;
   },
   
+  touchEnd: function(evt) {
+    this.mouseUp(evt);
+  },
+
   mouseUp: function(evt) {
     var monthStartOn = this.get('monthStartOn');
     

--- a/frameworks/calendar/views/calendar.js
+++ b/frameworks/calendar/views/calendar.js
@@ -17,6 +17,10 @@ SCUI.CalendarView = SC.View.extend({
     if (selectedDate) this.set('monthStartOn', selectedDate.adjust({ day: 1 }));
   },
   
+  touchStart: function(evt) {
+    this.mouseDown(evt);
+  },
+
   mouseDown: function(evt) {
     var date = this._parseSelectedDate(evt.target.id);
     if (date) this.set('selectedDate', date);
@@ -28,28 +32,29 @@ SCUI.CalendarView = SC.View.extend({
     return YES;
   },
   
+  touchEnd: function(evt) {
+    this.mouseUp(evt);
+  },
+
   mouseUp: function(evt) {
     var monthStartOn = this.get('monthStartOn');
     
-    var className = evt.target.className,
-        param;
-    
+    var className = evt.target.className, param;
+
     if (className.match('button')) {
       var unit = className.match('previous') ? -1 : 1;    
-    
+      
       if (className.match('year')) {
         param = {year: unit};
       } else {
         param = {month: unit};
       }
-    
+      
       this.set('monthStartOn', monthStartOn.advance(param));
-      this.$('.button.active').removeClass('active');
-      return YES;
-    } else {
-      return NO;
     }
     
+    this.$('.button.active').removeClass('active');
+    return YES;
   },
   
   render: function(context, firstTime) {
@@ -63,15 +68,11 @@ SCUI.CalendarView = SC.View.extend({
     
     context = context .begin('div').addClass('header')
                         .begin('div').addClass('month').text(monthStartOn.toFormattedString('%B %Y')).end()
-                        .begin('div').addClass('button previous').end()
-                        .begin('div').addClass('button next').end();
-
-    if (this.get('showYearButtons')) {
-      context = context .begin('div').addClass('button previous year').end()
-                        .begin('div').addClass('button next year').end();
-    }  
-                        
-    context = context .end()
+                        .begin('div').addClass('button month previous').end()
+                        .begin('div').addClass('button month next').end()
+                        .begin('div').addClass('button previous year').end()
+                        .begin('div').addClass('button next year').end()
+                      .end()
                       .begin('div').addClass('body');
     
     for (var i = 0; i < 7; i++) {

--- a/frameworks/calendar/views/calendar.js
+++ b/frameworks/calendar/views/calendar.js
@@ -39,17 +39,20 @@ SCUI.CalendarView = SC.View.extend({
     var monthStartOn = this.get('monthStartOn');
     
     var className = evt.target.className, param;
-    var unit = className.match('previous') ? -1 : 1;    
-    
-    if (className.match('year')) {
-      param = {year: unit};
-    } else {
-      param = {month: unit};
+
+    if (className.match('button')) {
+      var unit = className.match('previous') ? -1 : 1;    
+      
+      if (className.match('year')) {
+        param = {year: unit};
+      } else {
+        param = {month: unit};
+      }
+      
+      this.set('monthStartOn', monthStartOn.advance(param));
     }
     
-    this.set('monthStartOn', monthStartOn.advance(param));
     this.$('.button.active').removeClass('active');
-    
     return YES;
   },
   
@@ -64,8 +67,8 @@ SCUI.CalendarView = SC.View.extend({
     
     context = context .begin('div').addClass('header')
                         .begin('div').addClass('month').text(monthStartOn.toFormattedString('%B %Y')).end()
-                        .begin('div').addClass('button previous').end()
-                        .begin('div').addClass('button next').end()
+                        .begin('div').addClass('button month previous').end()
+                        .begin('div').addClass('button month next').end()
                         .begin('div').addClass('button previous year').end()
                         .begin('div').addClass('button next year').end()
                       .end()

--- a/frameworks/calendar/views/datepicker.js
+++ b/frameworks/calendar/views/datepicker.js
@@ -66,6 +66,7 @@ SCUI.DatePickerView = SC.View.extend(
       layout: {left: 0, top: 0, right: 0, bottom: 0},
       classNames: ['scui-datechooser-text'],
       isEnabled: YES,
+      isEditable: NO,
       valueBinding: SC.Binding.from('.dateString', that),
       hintBinding: SC.Binding.from('hint', that),
       mouseDown: function (evt) {

--- a/frameworks/calendar/views/timepicker.js
+++ b/frameworks/calendar/views/timepicker.js
@@ -107,9 +107,9 @@ SCUI.TimePickerView = SCUI.ComboBoxView.extend(
         dateTime = SC.DateTime.parse(value, format);
         if (dateTime && startTime) {
           dateTime = dateTime.adjust({
-            year: startTime.get('year'),
+            year:  startTime.get('year'),
             month: startTime.get('month'),
-            day:startTime.get('day')
+            day:   startTime.get('day')
           });
         }
       } catch(_){}

--- a/frameworks/calendar/views/timepicker.js
+++ b/frameworks/calendar/views/timepicker.js
@@ -25,11 +25,13 @@ SCUI.TimePickerView = SCUI.ComboBoxView.extend(
   dropDownButtonView: null,
   nameKey: null,
   valueKey: null,
+  hint:'Choose a time...',
 
   textFieldView: SC.TextFieldView.extend({
     classNames: 'scui-timepicker-text-field-view'.w(),
     layout: { top: 0, left: 0, bottom: 0, right: 0 },
     spellCheckEnabled: NO,
+    hintBinding: SC.Binding.from('hint', this),
     fieldDidFocus: function() {
       sc_super();
       var filteredObjects = this.parentView.get('filteredObjects');

--- a/frameworks/calendar/views/timepicker.js
+++ b/frameworks/calendar/views/timepicker.js
@@ -100,13 +100,19 @@ SCUI.TimePickerView = SCUI.ComboBoxView.extend(
     var textField = this.get('textFieldView'),
         format = this.get('timeFormat'),
         value = textField.get('value'),
+        startTime = this.get('startTime'),
         dateTime = null;
-
     if (!SC.empty(value)) {
       try {
         dateTime = SC.DateTime.parse(value, format);
-      } catch(exp){
-      }
+        if (dateTime && startTime) {
+          dateTime = dateTime.adjust({
+            year: startTime.get('year'),
+            month: startTime.get('month'),
+            day:startTime.get('day')
+          });
+        }
+      } catch(_){}
     }
 
     if (this.get('isEditing')) {
@@ -118,11 +124,11 @@ SCUI.TimePickerView = SCUI.ComboBoxView.extend(
         this.setIfChanged('selectedTime', dateTime);
         this.setIfChanged('value', value);
       }
-      // in IE, as soon as you the user browses through the results in the picker pane by 
-      // clicking on the scroll bar or the scroll thumb, the textfield loses focus causing 
-      // commitEditing to be called and subsequently hideList which makes for a very annoying 
-      // experience. With this change, clicking outside the pane will hide it (same as original behavior), 
-      // however, if the user directly shifts focus to another text field, then the pane 
+      // in IE, as soon as you the user browses through the results in the picker pane by
+      // clicking on the scroll bar or the scroll thumb, the textfield loses focus causing
+      // commitEditing to be called and subsequently hideList which makes for a very annoying
+      // experience. With this change, clicking outside the pane will hide it (same as original behavior),
+      // however, if the user directly shifts focus to another text field, then the pane
       // won't be removed. This behavior is still buggy but less buggy than it was before.
       if (!SC.browser.msie) {
         this.hideList();

--- a/frameworks/calendar/views/timepicker.js
+++ b/frameworks/calendar/views/timepicker.js
@@ -71,6 +71,8 @@ SCUI.TimePickerView = SCUI.ComboBoxView.extend(
     var times = [],
         step = this.get('step'),
         format = this.get('timeFormat'),
+        selTime = this.get('selectedTime'),
+        selTimeInserted = NO,
         time = this.get('startTime'),
         endTime = this.get('endTime');
     if (!(SC.DateTime.compare(time, endTime) < 0)) {
@@ -79,6 +81,10 @@ SCUI.TimePickerView = SCUI.ComboBoxView.extend(
     while(SC.DateTime.compare(time, endTime) <= 0) {
       times.push(time.toFormattedString(format));
       time = time.advance({minute: step});
+      if (!selTimeInserted && selTime && SC.DateTime.compare(time, selTime) >= 0) {
+          times.push(selTime.toFormattedString(format));
+          selTimeInserted = YES;
+      }
     }
     return times;
   }.property('startTime', 'endTime', 'step', 'timeFormat'),

--- a/frameworks/calendar/views/timepicker.js~
+++ b/frameworks/calendar/views/timepicker.js~
@@ -31,6 +31,7 @@ SCUI.TimePickerView = SCUI.ComboBoxView.extend(
     classNames: 'scui-timepicker-text-field-view'.w(),
     layout: { top: 0, left: 0, bottom: 0, right: 0 },
     spellCheckEnabled: NO,
+    hintBinding: SC.Binding.from('hint', this),
     fieldDidFocus: function() {
       sc_super();
       var filteredObjects = this.parentView.get('filteredObjects');

--- a/frameworks/foundation/english.lproj/loading_spinner.css
+++ b/frameworks/foundation/english.lproj/loading_spinner.css
@@ -17,5 +17,5 @@
   background-image:static_url('images/spinner-light-solid-black.png');
 }
 .loadingSpinner.lightSolidGreen{
-  background-image:static_url('images/light-solid-green.png');
+  background-image:static_url('images/spinner-light-solid-green.png');
 }

--- a/frameworks/foundation/english.lproj/modal_pane.css
+++ b/frameworks/foundation/english.lproj/modal_pane.css
@@ -4,7 +4,7 @@
   background: static_url('images/lower-right-drag.png') no-repeat;
 }
 .header {
-  background: static_url('images/header-bg.png') repeat-x;
+  background: static_url('images/title-bar-bg.png') repeat-x;
 }
 .header .modal-title {
   top: 10px !important;

--- a/frameworks/foundation/mixins/class_actions.js
+++ b/frameworks/foundation/mixins/class_actions.js
@@ -1,0 +1,214 @@
+
+/**
+ The SCUI.classActions mixin allows actions and custom mouse events for any
+ element that has a class on it. Useful for when you have a custom render method.
+
+ Class names that you want to attach an action to should be unique
+
+ Example:
+
+ {{{
+   SC.View.extend(SCUI.classActions, {
+
+     classActions: {
+       "search": {
+         target: 'Orion.globalSearchRecord',
+         action: 'show'
+       },
+       "help":   {target: 'Orion.helpController',     action: 'show'},
+       "logout": {
+         action: 'logout',
+         mouseMoved: function(evt) {
+
+         }
+       }
+     },
+
+     render: function(context, firstTime) {
+       context.push(
+         "<div class='sc-view search' title='", "_Search".loc(),"'><div></div></div>",
+         "<div class='sc-view help' "_Help".loc(),"'><div></div></div>",
+         "<div class='sc-view logout' "_Logout".loc(),"'><div></div></div>"
+       );
+     }
+
+   })
+ }}}
+
+ */
+SCUI.classActions = {
+  classActions:{},
+
+  hoverClass: 'hover',
+  activeClass: 'active',
+  _isContinuedMouseDown: NO,
+  _mouseDownClass: null,
+  _mouseOverClass: null,
+
+  /**
+   * Loop through the classActions object to get the keys, which will be class
+   * names that need actions.
+   */
+  _getClassNames: function() {
+    var classNames = this._classNames,
+        actions, name;
+    if(classNames) {
+      return classNames;
+    }
+
+    classNames = this._classNames = [];
+
+    actions = this.classActions;
+    for(name in actions){
+      if(actions.hasOwnProperty(name)) {
+        classNames.push(name);
+      }
+    }
+    return classNames;
+  },
+
+  _isInsideNamedClass: function(evt) {
+    var layer = this.get('layer');
+    if (!layer) return NO ; // no layer yet -- nothing to do
+
+    var classNames = this._getClassNames(),
+        el = SC.$(evt.target), i,
+        clength = classNames.length,
+        ret = NO ;
+
+    while(!ret && el.length>0 && (el[0] !== layer)) {
+      i = clength;
+      while(!ret && ((i--)>=0) ) {
+        if (el.hasClass(classNames[i])) ret = classNames[i] ;
+      }
+      el = el.parent() ;
+    }
+    el = layer = null; //avoid memory leaks
+    return ret ;
+  },
+
+  mouseDown: function(evt) {
+    var className = this._isInsideNamedClass(evt),
+        classDetails = this.classActions[className];
+
+    if(classDetails) {
+      this._mouseDown(className, evt, classDetails);
+      return YES;
+    }
+  },
+
+  mouseUp: function(evt) {
+    var className = this._isInsideNamedClass(evt),
+        classDetails = this.classActions[className];
+
+    if(classDetails) {
+      this._mouseUp(className, evt, classDetails);
+      return YES;
+    }
+  },
+
+//  mouseEntered: function(evt) {
+//
+//  },
+
+  mouseExited: function(evt) {
+    var overClass = this._mouseDownClass;
+    if(overClass) {
+      this._mouseExited(overClass, evt);
+    }
+  },
+
+  /**
+   * Event Dispatchers to subviews.
+   */
+  _mouseDown: function(className, evt, classDetails) {
+    if(!classDetails) classDetails = this.classActions[className];
+    this._isContinuedMouseDown = YES;
+    this._mouseDownClass = className;
+    this.$('.'+className).addClass(this.activeClass);
+    if (classDetails.mouseDown) classDetails.mouseDown(evt);
+  },
+
+  _mouseUp: function(className, evt, classDetails) {
+    var target, action;
+    if(!classDetails) classDetails = this.classActions[className];
+    console.log("Mouse Up ", this._mouseDownClass, className);
+    if (this._mouseDownClass == className) {
+      console.log('Run Action');
+      // Trigger the action
+      target = classDetails['target'] || null;
+      action = classDetails['action'];
+
+      this.getPath('pane.rootResponder')
+          .sendAction(action, target, this, this.get('pane'));
+    } else {
+      console.log('No Action!');
+    }
+    this.$('.'+className).removeClass(this.activeClass);
+    this._isContinuedMouseDown = NO;
+    this._mouseDownClass = null;
+  },
+
+  _mouseEntered: function(className, evt, classDetails) {
+    if(!classDetails) classDetails = this.classActions[className];
+
+    this.$('.'+className).addClass(this.hoverClass);
+    if (this._isContinuedMouseDown && this._mouseDownClass == className) {
+      this.$('.'+className).addClass(this.activeClass);
+    }
+    if (classDetails.mouseEntered) classDetails.mouseEntered(evt);
+    this._mouseOverClass = className;
+  },
+
+  _mouseExited: function(className, evt, classDetails) {
+    if(!classDetails) classDetails = this.classActions[className];
+
+    this.$('.'+className).removeClass(this.hoverClass).removeClass(this.activeClass);
+    if (classDetails.mouseExited) classDetails.mouseExited(evt);
+    this._mouseOverClass = null;
+  },
+
+  _mouseMoved:function(className, evt, classDetails) {
+    if(!classDetails) classDetails = this.classActions[className];
+    if (classDetails.mouseMoved) classDetails.mouseMoved(evt);
+  },
+
+  mouseMoved: function(evt) {
+    var className = this._isInsideNamedClass(evt),
+        classDetails = this.classActions[className],
+        overClass = this._mouseOverClass;
+    if(classDetails) {
+      if(className !== overClass) {
+        if(overClass) this._mouseExited(overClass, evt, classDetails);
+        this._mouseEntered(className, evt, classDetails);
+      }
+      this._mouseMoved(className, evt, classDetails);
+    } else if(overClass) {
+      this._mouseExited(overClass, evt, classDetails);
+    }
+  },
+
+//  mouseDragged: function(evt) {
+//    console.log('mouseDragged');
+//  },
+
+  // ..........................................................
+  // touch support
+  //
+  touchStart: function(evt){
+    return this.mouseDown(evt);
+  },
+
+  touchEnd: function(evt){
+    return this.mouseUp(evt);
+  },
+
+  touchEntered: function(evt){
+    return this.mouseEntered(evt);
+  },
+
+  touchExited: function(evt){
+    return this.mouseExited(evt);
+  }
+
+};

--- a/frameworks/foundation/views/combo_box.js
+++ b/frameworks/foundation/views/combo_box.js
@@ -316,8 +316,6 @@ SCUI.ComboBoxView = SC.View.extend( SC.Control, SC.Editable, {
     if (this._listPane) {
       this._listPane.destroy();
     }
-
-    sc_super();
   },
 
   createChildViews: function() {

--- a/frameworks/foundation/views/upload.js
+++ b/frameworks/foundation/views/upload.js
@@ -188,7 +188,6 @@ SCUI.UploadView = SC.View.extend(
   },
   
   didCreateLayer: function() {
-    sc_super();
     var frame = this.$('iframe');
     var input = this.$('input');
     

--- a/frameworks/foundation/views/upload.js
+++ b/frameworks/foundation/views/upload.js
@@ -12,6 +12,46 @@
   @author Evin Grano
 */
 
+// Add the bind() function to the Function prototype.
+SC.mixin(Function.prototype, {
+
+  /**
+   * This bind method was ported from the prototype for use in the AJAX callbacks.
+   *
+   *  Function#bind(object[, args...]) -> Function
+   *  - object (Object): The object to bind to.
+   *
+   *  Wraps the function in another, locking its execution scope to an object
+   *  specified by `object`.
+   */
+  bind: function (context) {
+    var slice = Array.prototype.slice;
+
+    var update = function(array, args) {
+      var arrayLength = array.length, length = args.length;
+      while (length--) array[arrayLength + length] = args[length];
+      return array;
+    };
+
+    var merge = function(array, args) {
+      array = slice.call(array, 0);
+      return update(array, args);
+    };
+
+    if (arguments.length < 2 && SC.none(arguments[0])) return this;
+    var __method = this, args = slice.call(arguments, 1);
+
+    return function() {
+      var a = merge(args, arguments);
+      // var a = args.concat(arguments);
+      return __method.apply(context, a);
+    };
+  }
+
+});
+
+
+
 SCUI.UploadView = SC.View.extend(
 /** @scope Scui.Upload.prototype */ {
   
@@ -175,7 +215,8 @@ SCUI.UploadView = SC.View.extend(
     file = input.files[0];
     fd = new FormData();
     fd.append(this.get('inputName'), file);
-    xhr = rp.copy();
+    xhr = rp.create();
+    xhr.set('type', 'POST');
     xhr.set('isJSON', false);
     xhr.set('isXML', false);
     xhr.set('address', this.get('uploadTarget'));

--- a/themes/standard_theme/resources/calendar.css
+++ b/themes/standard_theme/resources/calendar.css
@@ -1,0 +1,132 @@
+/* ==========================================================================
+*  Project:   StandardTheme Theme Styles
+*  Copyright: ©2011 My Company, Inc.
+*  ==========================================================================
+*/
+
+/* 
+  Place any styles you want to define in this file.  You can also break your
+  styles into multiple files.  Just add them to your resources or .lrpoj
+  directories to be included in the build.
+*/
+
+/* Core
+---------------------------------------------- */
+
+/* Header */
+
+.sc-theme .calendar > .header {
+  width: 203px;
+  height: 31px;
+  border: 1px solid #910009;
+  border-bottom-color: #5d0006;
+  background: #c20a17;
+	-webkit-border-radius: 4px 4px 0 0;
+	-moz-border-radius: 4px 4px 0 0;
+	border-radius: 4px 4px 0 0;
+	-webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, .6);
+	-moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, .6);
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, .6);
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f41c2f', endColorstr='#a5000a');
+  background: -webkit-gradient(linear, left top, left bottom, from(#f41c2f), to(#a5000a));
+  background: -moz-linear-gradient(top, #f41c2f, #a5000a);
+}
+
+.sc-theme .calendar .month {
+  margin: 0 29px;
+  color: #fff;
+  font-size: 14px;
+  line-height: 31px;
+  text-align: center;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, .7);
+}
+
+.sc-theme .calendar .button {
+  width: 9px;
+  height: 10px;
+  position: absolute;
+  top: 12px;
+}
+
+.sc-theme .calendar .previous {
+  left: 10px;
+}
+
+.sc-theme .calendar .next {
+  right: 10px;
+}
+
+/* Body */
+
+.sc-theme .calendar .body {
+  display: inline-block;
+  padding: 10px;
+  border: 1px solid #a6a09c;
+  border-top: 0;
+  background: #f7f2ee;
+	-webkit-border-radius: 0 0 4px 4px;
+	-moz-border-radius: 0 0 4px 4px;
+	border-radius: 0 0 4px 4px;
+}
+
+.sc-theme .calendar .grid {
+  width: 182px;
+  overflow: hidden;
+  border-top: 1px solid #c6c2be;
+  border-left: 1px solid #c6c2be;
+}
+
+.sc-theme .calendar .day {
+  width: 25px;
+  height: 25px;
+  float: left;
+  border-bottom: 1px solid #c6c2be;
+  border-right: 1px solid #c6c2be;
+  line-height: 25px;
+  text-align: center;
+}
+
+.sc-theme .calendar .day.header {
+  height: 12px;
+  border-color: transparent;
+  font-size: 10px;
+  line-height: 12px;
+}
+
+.sc-theme .calendar .day.present {
+  color: #353535;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, .7);
+  background: #ededea;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f8f8f7', endColorstr='#e1e0dc');
+  background: -webkit-gradient(linear, left top, left bottom, from(#f8f8f7), to(#e1e0dc));
+  background: -moz-linear-gradient(top, #f8f8f7, #e1e0dc);
+}
+
+.sc-theme .calendar .day.past {
+  color: #aaa;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, .7);
+  background: #f6f6f6;
+}
+
+.sc-theme .calendar .day.today {
+  color: #fff;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, .7);
+  background: #a2a8ae;
+	-webkit-box-shadow: inset 0 1px 3px rgba(0, 0, 0, .5);
+	-moz-box-shadow: inset 0 1px 3px rgba(0, 0, 0, .5);
+	box-shadow: inset 0 1px 3px rgba(0, 0, 0, .5);
+}
+
+.sc-theme .calendar .day.sel {
+  color: #fff;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, .7);
+  background: #db0c10;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f50f0f', endColorstr='#bd0915');
+  background: -webkit-gradient(linear, left top, left bottom, from(#f50f0f), to(#bd0915));
+  background: -moz-linear-gradient(top, #f50f0f, #bd0915);
+}
+
+body {
+	width: 205px;
+	height: 255px;
+}


### PR DESCRIPTION
Previously, TimePickerView overwrote year, month, and day value of
startDate when committing edits. This change respects those values.
